### PR TITLE
Fix grpc clients address update

### DIFF
--- a/src/Sitko.Core.Grpc.Client/GrpcClientModule.cs
+++ b/src/Sitko.Core.Grpc.Client/GrpcClientModule.cs
@@ -1,88 +1,56 @@
-namespace Sitko.Core.Grpc.Client
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sitko.Core.App;
+using Sitko.Core.Grpc.Client.Discovery;
+
+namespace Sitko.Core.Grpc.Client;
+
+public interface IGrpcClientModule<TClient> where TClient : ClientBase<TClient>
 {
-    using System;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Threading.Tasks;
-    using App;
-    using Discovery;
-    using global::Grpc.Core;
-    using global::Grpc.Core.Interceptors;
-    using Microsoft.Extensions.DependencyInjection;
+}
 
-    public interface IGrpcClientModule<TClient> where TClient : ClientBase<TClient>
+public abstract class GrpcClientModule<TClient, TResolver, TGrpcClientModuleOptions> :
+    BaseApplicationModule<TGrpcClientModuleOptions>,
+    IGrpcClientModule<TClient>
+    where TClient : ClientBase<TClient>
+    where TResolver : class, IGrpcServiceAddressResolver<TClient>
+    where TGrpcClientModuleOptions : GrpcClientModuleOptions<TClient>, new()
+{
+    public override void ConfigureServices(ApplicationContext context, IServiceCollection services,
+        TGrpcClientModuleOptions startupOptions)
     {
-    }
-
-    public abstract class GrpcClientModule<TClient, TResolver, TGrpcClientModuleOptions> :
-        BaseApplicationModule<TGrpcClientModuleOptions>,
-        IGrpcClientModule<TClient>
-        where TClient : ClientBase<TClient>
-        where TResolver : class, IGrpcServiceAddressResolver<TClient>
-        where TGrpcClientModuleOptions : GrpcClientModuleOptions<TClient>, new()
-    {
-        public override void ConfigureServices(ApplicationContext context, IServiceCollection services,
-            TGrpcClientModuleOptions startupOptions)
+        base.ConfigureServices(context, services, startupOptions);
+        if (startupOptions.EnableHttp2UnencryptedSupport)
         {
-            base.ConfigureServices(context, services, startupOptions);
-            if (startupOptions.EnableHttp2UnencryptedSupport)
-            {
-                AppContext.SetSwitch(
-                    "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-            }
-
-            services.AddSingleton<IGrpcClientProvider<TClient>, GrpcClientProvider<TClient>>();
-            RegisterResolver(services, startupOptions);
-            if (startupOptions.Interceptors.Any())
-            {
-                foreach (var type in startupOptions.Interceptors)
-                {
-                    services.AddSingleton(type);
-                }
-            }
-
-            services.AddGrpcClient<TClient>((provider, options) =>
-                {
-                    var config = GetOptions(provider);
-                    if (config.Interceptors.Any())
-                    {
-                        foreach (var service in config.Interceptors.Select(provider.GetService))
-                        {
-                            if (service is Interceptor interceptor)
-                            {
-                                options.Interceptors.Add(interceptor);
-                            }
-                        }
-                    }
-
-                    var resolver = provider.GetRequiredService<IGrpcServiceAddressResolver<TClient>>();
-                    options.Address = resolver.GetAddress();
-                })
-                .ConfigurePrimaryHttpMessageHandler(() =>
-                {
-                    var handler = new HttpClientHandler();
-                    if (startupOptions.DisableCertificatesValidation)
-                    {
-                        handler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
-                    }
-
-                    return handler;
-                }).ConfigureChannel(options =>
-                {
-                    startupOptions.ConfigureChannelOptions?.Invoke(options);
-                });
-            services.AddHealthChecks()
-                .AddCheck<GrpcClientHealthCheck<TClient>>($"GRPC Client check: {typeof(TClient)}");
+            AppContext.SetSwitch(
+                "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
         }
 
-        public override async Task InitAsync(ApplicationContext context, IServiceProvider serviceProvider)
+        services.AddSingleton<IGrpcClientProvider<TClient>, GrpcClientProvider<TClient, TGrpcClientModuleOptions>>();
+        RegisterResolver(services, startupOptions);
+        if (startupOptions.Interceptors.Any())
         {
-            await base.InitAsync(context, serviceProvider);
-            var resolver = serviceProvider.GetRequiredService<IGrpcServiceAddressResolver<TClient>>();
-            await resolver.InitAsync();
+            foreach (var type in startupOptions.Interceptors)
+            {
+                services.TryAddSingleton(type);
+            }
         }
 
-        protected virtual void RegisterResolver(IServiceCollection services, TGrpcClientModuleOptions config) =>
-            services.AddSingleton<IGrpcServiceAddressResolver<TClient>, TResolver>();
+        services.AddHealthChecks()
+            .AddCheck<GrpcClientHealthCheck<TClient>>($"GRPC Client check: {typeof(TClient)}");
     }
+
+    public override async Task InitAsync(ApplicationContext context, IServiceProvider serviceProvider)
+    {
+        await base.InitAsync(context, serviceProvider);
+        var resolver = serviceProvider.GetRequiredService<IGrpcServiceAddressResolver<TClient>>();
+        await resolver.InitAsync();
+    }
+
+    protected virtual void RegisterResolver(IServiceCollection services, TGrpcClientModuleOptions config) =>
+        services.AddSingleton<IGrpcServiceAddressResolver<TClient>, TResolver>();
 }

--- a/src/Sitko.Core.Grpc.Client/GrpcClientProvider.cs
+++ b/src/Sitko.Core.Grpc.Client/GrpcClientProvider.cs
@@ -1,43 +1,123 @@
-﻿namespace Sitko.Core.Grpc.Client
-{
-    using System;
-    using Discovery;
-    using global::Grpc.Core;
-    using global::Grpc.Net.ClientFactory;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Options;
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Grpc.Net.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sitko.Core.Grpc.Client.Discovery;
 
-    public interface IGrpcClientProvider<out TClient> where TClient : ClientBase<TClient>
+namespace Sitko.Core.Grpc.Client;
+
+public interface IGrpcClientProvider<out TClient> where TClient : ClientBase<TClient>
+{
+    TClient Instance { get; }
+    Uri? CurrentAddress { get; }
+}
+
+public class GrpcClientProvider<TClient, TOptions> : IGrpcClientProvider<TClient>
+    where TClient : ClientBase<TClient> where TOptions : GrpcClientModuleOptions<TClient>, new()
+{
+    private readonly ILogger<GrpcClientProvider<TClient, TOptions>> logger;
+    private readonly ILoggerFactory loggerFactory;
+
+    private readonly IOptionsMonitor<TOptions> optionsMonitor;
+
+    private readonly IGrpcServiceAddressResolver<TClient> resolver;
+
+    private readonly IServiceScopeFactory scopeFactory;
+
+    private CallInvoker? callInvoker;
+    private GrpcChannel? channel;
+
+    public GrpcClientProvider(IGrpcServiceAddressResolver<TClient> resolver, IOptionsMonitor<TOptions> optionsMonitor,
+        ILoggerFactory loggerFactory, IServiceScopeFactory scopeFactory,
+        ILogger<GrpcClientProvider<TClient, TOptions>> logger)
     {
-        TClient Instance { get; }
-        Uri? CurrentAddress { get; }
+        this.resolver = resolver;
+        this.optionsMonitor = optionsMonitor;
+        this.loggerFactory = loggerFactory;
+        this.scopeFactory = scopeFactory;
+        this.logger = logger;
+        this.resolver.OnChange += (_, _) => OnChange();
+        CurrentAddress = this.resolver.GetAddress();
     }
 
-    public class GrpcClientProvider<TClient> : IGrpcClientProvider<TClient>
-        where TClient : ClientBase<TClient>
+    private TOptions Options => optionsMonitor.CurrentValue;
+
+    public TClient Instance
     {
-        private readonly IOptionsMonitor<GrpcClientFactoryOptions> clientFactoryOptionsMonitor;
-        private readonly IGrpcServiceAddressResolver<TClient> resolver;
-        private readonly IServiceProvider serviceProvider;
-
-        public GrpcClientProvider(IServiceProvider serviceProvider,
-            IOptionsMonitor<GrpcClientFactoryOptions> clientFactoryOptionsMonitor,
-            IGrpcServiceAddressResolver<TClient> resolver)
+        get
         {
-            this.serviceProvider = serviceProvider;
-            this.clientFactoryOptionsMonitor = clientFactoryOptionsMonitor;
-            this.resolver = resolver;
-            this.resolver.OnChange += (_, _) => OnChange();
-            CurrentAddress = this.resolver.GetAddress();
+            if (Activator.CreateInstance(typeof(TClient), GetOrCreateCallInvoker()) is not TClient client)
+            {
+                throw new InvalidOperationException($"Can't create client of type {typeof(TClient)}");
+            }
+
+            return client;
+        }
+    }
+
+    public Uri? CurrentAddress { get; private set; }
+
+    private CallInvoker GetOrCreateCallInvoker()
+    {
+        if (callInvoker is not null)
+        {
+            return callInvoker;
         }
 
-        public TClient Instance => serviceProvider.GetRequiredService<TClient>();
-        public Uri? CurrentAddress { get; private set; }
-
-        private void OnChange()
+        if (CurrentAddress is null)
         {
-            var options = clientFactoryOptionsMonitor.Get(typeof(TClient).Name);
-            CurrentAddress = options.Address = resolver.GetAddress();
+            throw new InvalidOperationException($"No address for service {typeof(TClient)}");
         }
+
+        logger.LogInformation("Create new channel for client {Client} to {Address}", typeof(TClient), CurrentAddress);
+        var scope = scopeFactory.CreateScope();
+        var services = scope.ServiceProvider;
+        var options = new GrpcChannelOptions();
+
+        if (Options.DisableCertificatesValidation)
+        {
+            var handler = new HttpClientHandler();
+            handler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+            options.HttpHandler = handler;
+        }
+
+        options.ServiceProvider = services;
+        options.LoggerFactory = loggerFactory;
+        Options.ConfigureChannelOptions?.Invoke(options);
+
+        channel = GrpcChannel.ForAddress(CurrentAddress, options);
+        var httpClientCallInvoker = channel.CreateCallInvoker();
+        var interceptors = new List<Interceptor>();
+        foreach (var interceptorType in Options.Interceptors)
+        {
+            var interceptorInstance = services.GetService(interceptorType);
+            if (interceptorInstance is Interceptor interceptor)
+            {
+                interceptors.Add(interceptor);
+            }
+        }
+
+        callInvoker = httpClientCallInvoker;
+        if (interceptors.Count > 0)
+        {
+            callInvoker = httpClientCallInvoker.Intercept(interceptors.ToArray());
+        }
+
+        return callInvoker;
+    }
+
+    private void OnChange()
+    {
+        var newAddress = resolver.GetAddress();
+        logger.LogInformation("Address for client {Client} changed from {OldAddress} to {NewAddress}", typeof(TClient),
+            CurrentAddress, newAddress);
+        CurrentAddress = newAddress;
+        channel?.Dispose();
+        callInvoker = null;
     }
 }


### PR DESCRIPTION
Official Grpc.Net doesn't support updating address for service on-the-fly. Once configured it will always be the same. Our current approach with updating it with changing options instance is not very reliable. So now we will create channel and client in provider instead of loading from DI to ensure correct address will be used.

Refs: SITKO-CORE-T-3