### PR TITLE
Rework HostApplication build process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,15 +197,6 @@ jobs:
       - name: Start Vault
         run: |
           vault server -dev -dev-root-token-id="${VAULT__TOKEN}" &
-      - name: Seed Vault
-        run: |
-          export VAULT_ADDR=${VAULT__URI}
-          json='{"test": {"Foo": "123","Bar": 123}}'
-          echo $json > data.json
-          vault kv put ${VAULT__MOUNTPOINT}/${VAULT__SECRETS__0} @data.json
-          json='{"test2": {"Foo": "123","Bar": 123}}'
-          echo $json > data.json
-          vault kv put ${VAULT__MOUNTPOINT}/${VAULT__SECRETS__1} @data.json
       - name: Add Github Actions logger
         run: dotnet add src/Sitko.Core.Xunit/Sitko.Core.Xunit.csproj package GitHubActionsTestLogger
       - name: Run tests

--- a/src/Sitko.Core.App.Web/WebApplication.cs
+++ b/src/Sitko.Core.App.Web/WebApplication.cs
@@ -16,7 +16,8 @@ public abstract class WebApplication : HostedApplication
     }
 
     protected List<IWebApplicationModule> GetWebModules(IApplicationContext context) =>
-        GetEnabledModuleRegistrations(context).Select(r => r.GetInstance()).OfType<IWebApplicationModule>()
+        GetEnabledModuleRegistrations<IWebApplicationModule>(context).Select(r => r.GetInstance())
+            .OfType<IWebApplicationModule>()
             .ToList();
 
     public virtual void AppBuilderHook(IApplicationContext applicationContext,

--- a/src/Sitko.Core.App/Application.cs
+++ b/src/Sitko.Core.App/Application.cs
@@ -205,7 +205,7 @@ public abstract class Application : IApplication, IAsyncDisposable
         {
             var result =
                 registration.CheckRequiredModules(context,
-                    GetEnabledModuleRegistrations(context).Select(r => r.Type).ToArray());
+                    enabledModules.Select(r => r.Type).ToArray());
             if (!result.isSuccess)
             {
                 foreach (var missingModule in result.missingModules)

--- a/src/Sitko.Core.App/Application.cs
+++ b/src/Sitko.Core.App/Application.cs
@@ -117,7 +117,7 @@ public abstract class Application : IApplication, IAsyncDisposable
         }
 
         LogInternal("Configure app configuration in modules");
-        foreach (var moduleRegistration in GetEnabledModuleRegistrations(appContext))
+        foreach (var moduleRegistration in GetEnabledModuleRegistrations<IConfigurationModule>(appContext))
         {
             moduleRegistration.ConfigureAppConfiguration(appContext, builder);
         }
@@ -131,7 +131,7 @@ public abstract class Application : IApplication, IAsyncDisposable
             loggerConfiguration.MinimumLevel.Override(key, value);
         }
 
-        foreach (var moduleRegistration in GetEnabledModuleRegistrations(applicationContext))
+        foreach (var moduleRegistration in GetEnabledModuleRegistrations<ILoggingModule>(applicationContext))
         {
             moduleRegistration.ConfigureLogging(applicationContext, loggerConfiguration);
         }

--- a/src/Sitko.Core.App/Application.cs
+++ b/src/Sitko.Core.App/Application.cs
@@ -67,10 +67,13 @@ public abstract class Application : IApplication, IAsyncDisposable
     [PublicAPI]
     public ApplicationOptions GetApplicationOptions() => GetContext().Options;
 
+    protected IReadOnlyList<ApplicationModuleRegistration> GetEnabledModuleRegistrations(IApplicationContext context) =>
+        GetEnabledModuleRegistrations<IApplicationModule>(context);
 
     protected IReadOnlyList<ApplicationModuleRegistration>
-        GetEnabledModuleRegistrations(IApplicationContext context) => moduleRegistrations
-        .Where(r => r.IsEnabled(context)).ToList();
+        GetEnabledModuleRegistrations<TModule>(IApplicationContext context) where TModule : IApplicationModule =>
+        moduleRegistrations
+            .Where(r => r.GetInstance() is TModule && r.IsEnabled(context)).ToList();
 
 
     protected virtual void ConfigureHostConfiguration(IConfigurationBuilder configurationBuilder)

--- a/src/Sitko.Core.App/ApplicationModuleRegistration.cs
+++ b/src/Sitko.Core.App/ApplicationModuleRegistration.cs
@@ -132,15 +132,20 @@ internal class ApplicationModuleRegistration<TModule, TModuleOptions> : Applicat
 
     private TModuleOptions CreateOptions(IApplicationContext applicationContext, bool validateOptions = false)
     {
+        TModuleOptions options;
         if (optionsCache.ContainsKey(applicationContext.Id))
         {
-            return optionsCache[applicationContext.Id];
+            options = optionsCache[applicationContext.Id];
+        }
+        else
+        {
+            options = Activator.CreateInstance<TModuleOptions>();
+            applicationContext.Configuration.Bind(optionsKey, options);
+            options.Configure(applicationContext);
+            configureOptions?.Invoke(applicationContext, options);
+            optionsCache[applicationContext.Id] = options;
         }
 
-        var options = Activator.CreateInstance<TModuleOptions>();
-        applicationContext.Configuration.Bind(optionsKey, options);
-        options.Configure(applicationContext);
-        configureOptions?.Invoke(applicationContext, options);
         if (validatorType is not null && validateOptions)
         {
             try
@@ -162,7 +167,6 @@ internal class ApplicationModuleRegistration<TModule, TModuleOptions> : Applicat
             }
         }
 
-        optionsCache[applicationContext.Id] = options;
         return options;
     }
 

--- a/src/Sitko.Core.App/ApplicationModuleRegistration.cs
+++ b/src/Sitko.Core.App/ApplicationModuleRegistration.cs
@@ -19,6 +19,8 @@ internal class ApplicationModuleRegistration<TModule, TModuleOptions> : Applicat
 {
     private readonly Action<IApplicationContext, TModuleOptions>? configureOptions;
     private readonly TModule instance;
+
+    private readonly Dictionary<Guid, TModuleOptions> optionsCache = new();
     private readonly string? optionsKey;
     private readonly Type? validatorType;
 
@@ -130,6 +132,11 @@ internal class ApplicationModuleRegistration<TModule, TModuleOptions> : Applicat
 
     private TModuleOptions CreateOptions(IApplicationContext applicationContext, bool validateOptions = false)
     {
+        if (optionsCache.ContainsKey(applicationContext.Id))
+        {
+            return optionsCache[applicationContext.Id];
+        }
+
         var options = Activator.CreateInstance<TModuleOptions>();
         applicationContext.Configuration.Bind(optionsKey, options);
         options.Configure(applicationContext);
@@ -155,6 +162,7 @@ internal class ApplicationModuleRegistration<TModule, TModuleOptions> : Applicat
             }
         }
 
+        optionsCache[applicationContext.Id] = options;
         return options;
     }
 

--- a/src/Sitko.Core.App/HostedApplication.cs
+++ b/src/Sitko.Core.App/HostedApplication.cs
@@ -135,7 +135,7 @@ public abstract class HostedApplication : Application
             {
                 RegisterApplicationServices<HostedApplicationContext>(bootApplicationContext, services);
                 services.AddHostedService<ApplicationLifetimeService>();
-            }).ConfigureLogging((context, builder) =>
+            }).ConfigureLogging((_, builder) =>
             {
                 LogInternal("Configure logging");
                 LoggingExtensions.ConfigureSerilog(bootApplicationContext, builder, serilogConfiguration,

--- a/src/Sitko.Core.App/IApplicationContext.cs
+++ b/src/Sitko.Core.App/IApplicationContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
@@ -9,6 +10,7 @@ namespace Sitko.Core.App;
 
 public interface IApplicationContext
 {
+    Guid Id { get; }
     string Name { get; }
     string Version { get; }
     ApplicationOptions Options { get; }
@@ -37,6 +39,7 @@ public abstract class BaseApplicationContext : IApplicationContext
 
     public ApplicationOptions Options => GetApplicationOptions();
 
+    public Guid Id { get; } = Guid.NewGuid();
     public string Name => Options.Name;
     public string Version => Options.Version;
 

--- a/src/Sitko.Core.App/IApplicationModule.cs
+++ b/src/Sitko.Core.App/IApplicationModule.cs
@@ -38,7 +38,11 @@ public interface IApplicationModule
         string[] args);
 }
 
-public interface IHostBuilderModule<in TModuleOptions> : IApplicationModule<TModuleOptions>
+public interface IHostBuilderModule : IApplicationModule
+{
+}
+
+public interface IHostBuilderModule<in TModuleOptions> : IHostBuilderModule, IApplicationModule<TModuleOptions>
     where TModuleOptions : class, new()
 {
     public void ConfigureHostBuilder(IApplicationContext context, IHostBuilder hostBuilder,

--- a/src/Sitko.Core.App/IApplicationModule.cs
+++ b/src/Sitko.Core.App/IApplicationModule.cs
@@ -49,14 +49,18 @@ public interface IHostBuilderModule<in TModuleOptions> : IHostBuilderModule, IAp
         TModuleOptions startupOptions);
 }
 
-public interface ILoggingModule<in TModuleOptions> : IApplicationModule<TModuleOptions>
+public interface ILoggingModule : IApplicationModule
+{
+}
+
+public interface ILoggingModule<in TModuleOptions> : ILoggingModule, IApplicationModule<TModuleOptions>
     where TModuleOptions : class, new()
 {
     void ConfigureLogging(IApplicationContext context, TModuleOptions options,
         LoggerConfiguration loggerConfiguration);
 }
 
-public interface IConfigurationModule
+public interface IConfigurationModule : IApplicationModule
 {
     void CheckConfiguration(IApplicationContext context, IServiceProvider serviceProvider);
 }

--- a/src/Sitko.Core.Xunit/BaseTestScope.cs
+++ b/src/Sitko.Core.Xunit/BaseTestScope.cs
@@ -78,21 +78,26 @@ public abstract class BaseTestScope<TApplication, TConfig> : IBaseTestScope
     public virtual Task BeforeConfiguredAsync() => Task.CompletedTask;
     public virtual Task OnCreatedAsync() => Task.CompletedTask;
 
+    private bool isDisposed;
 
     public async ValueTask DisposeAsync()
     {
-        await OnDisposeAsync();
-        if (scopeApplication != null)
+        if (!isDisposed)
         {
-            if (isApplicationStarted)
+            await OnDisposeAsync();
+            if (scopeApplication != null)
             {
-                await scopeApplication.StopAsync();
+                if (isApplicationStarted)
+                {
+                    await scopeApplication.StopAsync();
+                }
+
+                await scopeApplication.DisposeAsync();
             }
 
-            await scopeApplication.DisposeAsync();
+            GC.SuppressFinalize(this);
+            isDisposed = true;
         }
-
-        GC.SuppressFinalize(this);
     }
 
     public async Task StartApplicationAsync()

--- a/src/Sitko.Core.Xunit/BaseTestScope.cs
+++ b/src/Sitko.Core.Xunit/BaseTestScope.cs
@@ -79,8 +79,9 @@ public abstract class BaseTestScope<TApplication, TConfig> : IBaseTestScope
     public virtual Task OnCreatedAsync() => Task.CompletedTask;
 
 
-    public virtual async ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        await OnDisposeAsync();
         if (scopeApplication != null)
         {
             if (isApplicationStarted)
@@ -102,6 +103,8 @@ public abstract class BaseTestScope<TApplication, TConfig> : IBaseTestScope
             isApplicationStarted = true;
         }
     }
+
+    protected virtual Task OnDisposeAsync() => Task.CompletedTask;
 
     public TConfig GetConfig(IConfiguration configuration)
     {

--- a/src/Sitko.Core.Xunit/DbBaseTestScope.cs
+++ b/src/Sitko.Core.Xunit/DbBaseTestScope.cs
@@ -87,15 +87,13 @@ public abstract class DbBaseTestScope<TApplication, TConfig> : BaseTestScope<TAp
         (TDbContext)(dbContexts.Find(dbContext => dbContext is TDbContext) ??
                      throw new InvalidOperationException("Db context is null"));
 
-    public override async ValueTask DisposeAsync()
+    protected override async Task OnDisposeAsync()
     {
+        await base.OnDisposeAsync();
         foreach (var dbContext in dbContexts)
         {
             await dbContext.Database.EnsureDeletedAsync();
         }
-
-        await base.DisposeAsync();
-        GC.SuppressFinalize(this);
     }
 }
 

--- a/tests/Sitko.Core.Configuration.Vault.Tests/ConfigurationTest.cs
+++ b/tests/Sitko.Core.Configuration.Vault.Tests/ConfigurationTest.cs
@@ -18,8 +18,8 @@ public class ConfigurationTest : BaseVaultTest
     {
         var scope = await GetScopeAsync();
         var config = scope.GetService<IOptionsMonitor<TestConfig>>();
-        Assert.NotEqual(string.Empty, config.CurrentValue.Foo);
-        Assert.NotEqual(0, config.CurrentValue.Bar);
+        config.CurrentValue.Foo.Should().Be(scope.FirstConfig.Foo);
+        config.CurrentValue.Bar.Should().Be(scope.FirstConfig.Bar);
     }
 
     [Fact]
@@ -27,8 +27,8 @@ public class ConfigurationTest : BaseVaultTest
     {
         var scope = await GetScopeAsync();
         var config = scope.GetService<IOptionsMonitor<TestConfig2>>();
-        Assert.NotEqual(string.Empty, config.CurrentValue.Foo);
-        Assert.NotEqual(0, config.CurrentValue.Bar);
+        config.CurrentValue.Foo.Should().Be(scope.SecondConfig.Foo);
+        config.CurrentValue.Bar.Should().Be(scope.SecondConfig.Bar);
     }
 
     [Fact]
@@ -36,8 +36,8 @@ public class ConfigurationTest : BaseVaultTest
     {
         var scope = await GetScopeAsync();
         var config = scope.GetService<IOptionsMonitor<TestModuleConfig>>();
-        Assert.NotEqual(string.Empty, config.CurrentValue.Foo);
-        Assert.NotEqual(0, config.CurrentValue.Bar);
+        config.CurrentValue.Foo.Should().Be(scope.FirstConfig.Foo);
+        config.CurrentValue.Bar.Should().Be(scope.FirstConfig.Bar);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class ConfigurationTest : BaseVaultTest
         {
             await GetScopeAsync<VaultTestScopeWithValidationFailure>();
         });
-        result.Message.Should().Contain("Bar must equals zero");
+        result.Message.Should().Contain("Bar must be empty!");
     }
 
     [Fact]

--- a/tests/Sitko.Core.Storage.FileSystem.Tests/BaseFileSystemStorageTestScope.cs
+++ b/tests/Sitko.Core.Storage.FileSystem.Tests/BaseFileSystemStorageTestScope.cs
@@ -3,31 +3,29 @@ using System.IO;
 using System.Threading.Tasks;
 using Sitko.Core.Xunit;
 
-namespace Sitko.Core.Storage.FileSystem.Tests
+namespace Sitko.Core.Storage.FileSystem.Tests;
+
+public class BaseFileSystemStorageTestScope : BaseTestScope
 {
-    public class BaseFileSystemStorageTestScope : BaseTestScope
+    private readonly string folder = Path.GetTempPath() + "/" + Guid.NewGuid();
+
+    protected override TestApplication ConfigureApplication(TestApplication application, string name)
     {
-        private readonly string folder = Path.GetTempPath() + "/" + Guid.NewGuid();
+        base.ConfigureApplication(application, name);
+        application.AddFileSystemStorage<TestFileSystemStorageSettings>(
+            moduleOptions =>
+            {
+                moduleOptions.PublicUri = new Uri(folder);
+                moduleOptions.StoragePath = folder;
+            });
+        application.AddFileSystemStorageMetadata<TestFileSystemStorageSettings>();
+        return application;
+    }
 
-        protected override TestApplication ConfigureApplication(TestApplication application, string name)
-        {
-            base.ConfigureApplication(application, name);
-            application.AddFileSystemStorage<TestFileSystemStorageSettings>(
-                moduleOptions =>
-                {
-                    moduleOptions.PublicUri = new Uri(folder);
-                    moduleOptions.StoragePath = folder;
-                });
-            application.AddFileSystemStorageMetadata<TestFileSystemStorageSettings>();
-            return application;
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            var storage = GetService<IStorage<TestFileSystemStorageSettings>>();
-            await storage.DeleteAllAsync();
-            await base.DisposeAsync();
-            GC.SuppressFinalize(this);
-        }
+    protected override async Task OnDisposeAsync()
+    {
+        await base.OnDisposeAsync();
+        var storage = GetService<IStorage<TestFileSystemStorageSettings>>();
+        await storage.DeleteAllAsync();
     }
 }

--- a/tests/Sitko.Core.Storage.Metadata.Postgres.Tests/BasePostgresStorageTestScope.cs
+++ b/tests/Sitko.Core.Storage.Metadata.Postgres.Tests/BasePostgresStorageTestScope.cs
@@ -1,34 +1,31 @@
-using System;
 using System.Threading.Tasks;
 using Sitko.Core.Storage.S3;
 using Sitko.Core.Xunit;
 
-namespace Sitko.Core.Storage.Metadata.Postgres.Tests
-{
-    public class BasePostgresStorageTestScope : BaseTestScope
-    {
-        protected override TestApplication ConfigureApplication(TestApplication application, string name)
-        {
-            base.ConfigureApplication(application, name);
-            application.AddS3Storage<TestS3StorageSettings>(moduleOptions =>
-            {
-                moduleOptions.Bucket = name.ToLowerInvariant();
-                moduleOptions.Prefix = "test";
-            });
-            application.AddPostgresStorageMetadata<TestS3StorageSettings>(
-                moduleOptions =>
-                {
-                    moduleOptions.Database = name;
-                });
-            return application;
-        }
+namespace Sitko.Core.Storage.Metadata.Postgres.Tests;
 
-        public override async ValueTask DisposeAsync()
+public class BasePostgresStorageTestScope : BaseTestScope
+{
+    protected override TestApplication ConfigureApplication(TestApplication application, string name)
+    {
+        base.ConfigureApplication(application, name);
+        application.AddS3Storage<TestS3StorageSettings>(moduleOptions =>
         {
-            var storage = GetService<IStorage<TestS3StorageSettings>>();
-            await storage.DeleteAllAsync();
-            await base.DisposeAsync();
-            GC.SuppressFinalize(this);
-        }
+            moduleOptions.Bucket = name.ToLowerInvariant();
+            moduleOptions.Prefix = "test";
+        });
+        application.AddPostgresStorageMetadata<TestS3StorageSettings>(
+            moduleOptions =>
+            {
+                moduleOptions.Database = name;
+            });
+        return application;
+    }
+
+    protected override async Task OnDisposeAsync()
+    {
+        await base.OnDisposeAsync();
+        var storage = GetService<IStorage<TestS3StorageSettings>>();
+        await storage.DeleteAllAsync();
     }
 }

--- a/tests/Sitko.Core.Storage.Remote.Tests/BaseRemoteStorageTestScope.cs
+++ b/tests/Sitko.Core.Storage.Remote.Tests/BaseRemoteStorageTestScope.cs
@@ -45,7 +45,6 @@ public class BaseRemoteStorageTestScope : BaseTestScope
         await base.OnDisposeAsync();
         var storage = GetService<IStorage<TestRemoteStorageSettings>>();
         await storage.DeleteAllAsync();
-        await DisposeAsync();
         if (host is not null)
         {
             await host.StopAsync();

--- a/tests/Sitko.Core.Storage.Remote.Tests/BaseRemoteStorageTestScope.cs
+++ b/tests/Sitko.Core.Storage.Remote.Tests/BaseRemoteStorageTestScope.cs
@@ -40,17 +40,16 @@ public class BaseRemoteStorageTestScope : BaseTestScope
         return application;
     }
 
-    public override async ValueTask DisposeAsync()
+    protected override async Task OnDisposeAsync()
     {
+        await base.OnDisposeAsync();
         var storage = GetService<IStorage<TestRemoteStorageSettings>>();
         await storage.DeleteAllAsync();
-        await base.DisposeAsync();
+        await DisposeAsync();
         if (host is not null)
         {
             await host.StopAsync();
             host.Dispose();
         }
-
-        GC.SuppressFinalize(this);
     }
 }

--- a/tests/Sitko.Core.Storage.S3.Tests/BaseS3StorageTestScope.cs
+++ b/tests/Sitko.Core.Storage.S3.Tests/BaseS3StorageTestScope.cs
@@ -2,31 +2,29 @@ using System;
 using System.Threading.Tasks;
 using Sitko.Core.Xunit;
 
-namespace Sitko.Core.Storage.S3.Tests
+namespace Sitko.Core.Storage.S3.Tests;
+
+public class BaseS3StorageTestScope : BaseTestScope
 {
-    public class BaseS3StorageTestScope : BaseTestScope
+    private readonly Guid bucketName = Guid.NewGuid();
+
+    protected override TestApplication ConfigureApplication(TestApplication application, string name)
     {
-        private Guid bucketName = Guid.NewGuid();
-
-        protected override TestApplication ConfigureApplication(TestApplication application, string name)
+        base.ConfigureApplication(application, name);
+        application.AddS3Storage<TestS3StorageSettings>(moduleOptions =>
         {
-            base.ConfigureApplication(application, name);
-            application.AddS3Storage<TestS3StorageSettings>(moduleOptions =>
-            {
-                moduleOptions.Bucket = bucketName.ToString().ToLowerInvariant();
-                moduleOptions.Prefix = "test";
-            });
-            application.AddS3StorageMetadata<TestS3StorageSettings>();
+            moduleOptions.Bucket = bucketName.ToString().ToLowerInvariant();
+            moduleOptions.Prefix = "test";
+        });
+        application.AddS3StorageMetadata<TestS3StorageSettings>();
 
-            return application;
-        }
+        return application;
+    }
 
-        public override async ValueTask DisposeAsync()
-        {
-            var storage = GetService<IStorage<TestS3StorageSettings>>();
-            await storage.DeleteAllAsync();
-            await base.DisposeAsync();
-            GC.SuppressFinalize(this);
-        }
+    protected override async Task OnDisposeAsync()
+    {
+        await base.OnDisposeAsync();
+        var storage = GetService<IStorage<TestS3StorageSettings>>();
+        await storage.DeleteAllAsync();
     }
 }


### PR DESCRIPTION
1. Do not create tmp host builder
2. Create IConfiguration with all providers before creating HostBuilder
3. Process all modules using full configuration data

Perf features:

1. Process only needed type of modules in configuration/logging/hostbuilder hooks
2. Reuse application contexts
3. Cache module options