### PR TITLE
Use Remote.LINQ to fix arrays and lists serialization

### DIFF
--- a/src/Sitko.Core.Repository.Remote/SerializedQuery.cs
+++ b/src/Sitko.Core.Repository.Remote/SerializedQuery.cs
@@ -24,8 +24,7 @@ public record SerializedQuery<TEntity> where TEntity : class
 
     public Expression<Func<TEntity, TValue>> SelectExpression<TValue>() => Data.SelectExpressionString is null
         ? throw new InvalidOperationException("Empty select expression")
-        : Deserialize<Expression<Func<TEntity, TValue>>>(Data.SelectExpressionString)
-        !;
+        : Deserialize<Expression<Func<TEntity, TValue>>>(Data.SelectExpressionString);
 
     public SerializedQuery<TEntity> SetSelectExpression(Expression selectExpression)
     {

--- a/src/Sitko.Core.Repository.Remote/Sitko.Core.Repository.Remote.csproj
+++ b/src/Sitko.Core.Repository.Remote/Sitko.Core.Repository.Remote.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.78.0"/>
-    <PackageReference Include="Serialize.Linq" Version="2.0.0"/>
-  </ItemGroup>
+    <PackageReference Include="Remote.Linq.Newtonsoft.Json" Version="7.1.0"/>
+   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Old library causes error on `Contains` conditions serialization

```
Error converting type: Type 'System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]' with data contract name 'ArrayOfint:http://schemas.microsoft.com/2003/10/Serialization/Arrays' is not expected. Consider using a DataContractResolver if you are using DataContractSerializer or add any types not known statically to the list of known types - for example, by using the KnownTypeAttribute attribute or by adding them to the list of known types passed to the serializer.
```

You can use `AutoAddKnownTypesAsListTypes = true`, but then arrays stops working. Can't use both because of [System.Runtime.Serialization](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization?view=net-7.0) behavior. Switched to [Remote.Linq](https://github.com/6bee/Remote.Linq) with different serialization algorithm.