### PR TITLE
Blazor form templates rework

### DIFF
--- a/apps/Sitko.Core.Apps.MudBlazorDemo/Forms/BarForm.cs
+++ b/apps/Sitko.Core.Apps.MudBlazorDemo/Forms/BarForm.cs
@@ -31,9 +31,5 @@ namespace Sitko.Core.Apps.MudBlazorDemo.Forms
         }
 
         public void DeleteFoo() => Entity.Foo = null;
-
-        [Parameter] public RenderFragment<BarForm> ChildContent { get; set; } = null!;
-
-        protected override RenderFragment ChildContentFragment => ChildContent(this);
     }
 }

--- a/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Index.razor
+++ b/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Index.razor
@@ -21,7 +21,7 @@
 </MudGrid>
 
 <MudPageLayout Title="@LocalizationProvider["Title"]">
-    <BarRepositoryList @bind-RowsPerPage="RowsPerPage" OnDataLoaded="CountSummaryAsync" @ref="barList" Class="mb-10" EnableUrlNavigation="true"
+    <BarRepositoryList @bind-RowsPerPage="rowsPerPage" OnDataLoaded="CountSummaryAsync" @ref="barList" Class="mb-10" EnableUrlNavigation="true"
                        ConfigureQuery="ConfigureQueryAsync" AddParamsToUrl="AddParamsToUrlAsync"
                        GetParamsFromUrl="GetParamsFromUrlAsync">
         <HeaderContent>

--- a/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Index.razor.cs
+++ b/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Index.razor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -13,10 +14,11 @@ namespace Sitko.Core.Apps.MudBlazorDemo.Pages
 {
     public partial class Index
     {
-        private int RowsPerPage = 10;
+        private int rowsPerPage = 10;
         private const string FilterParamId = "id";
         private const string FilterParamTitle = "title";
         private const string FilterParamDateRange = "dateRange";
+
         [Parameter]
         [SupplyParameterFromQuery(Name = FilterParamId)]
         public Guid? Id { get; set; }
@@ -75,9 +77,9 @@ namespace Sitko.Core.Apps.MudBlazorDemo.Pages
         //
 
         private FilterList FilterList { get; set; } = new();
-        private MudAutocomplete<BarModel> IdFilterAutocomplete { get; set; }
+        private MudAutocomplete<BarModel> IdFilterAutocomplete { get; set; } = null!;
 
-        [Inject] private BarRepository BarRepository { get; set; }
+        [Inject] private BarRepository BarRepository { get; set; } = null!;
         private (BarModel[] items, int itemsCount) bars;
 
         protected override async Task InitializeAsync()
@@ -112,11 +114,12 @@ namespace Sitko.Core.Apps.MudBlazorDemo.Pages
         private Task ConfigureQueryAsync(IRepositoryQuery<BarModel> query)
         {
             query
-                .Where(p => FilterList.Model == null || FilterList.Model.Id == Guid.Empty || p.Id == FilterList.Model.Id)
+                .Where(p => FilterList.Model == null || FilterList.Model.Id == Guid.Empty ||
+                            p.Id == FilterList.Model.Id)
                 .Where(p => string.IsNullOrEmpty(FilterList.Title) || p.Bar == FilterList.Title)
                 .Where(p => FilterList.DateRange == null ||
-                            p.Date >= new DateTimeOffset((DateTime)FilterList.DateRange.Start).UtcDateTime &&
-                            p.Date <= new DateTimeOffset((DateTime)FilterList.DateRange.End).UtcDateTime);
+                            (p.Date >= new DateTimeOffset((DateTime)FilterList.DateRange.Start!).UtcDateTime &&
+                             p.Date <= new DateTimeOffset((DateTime)FilterList.DateRange.End!).UtcDateTime));
 
             return Task.CompletedTask;
         }
@@ -159,7 +162,8 @@ namespace Sitko.Core.Apps.MudBlazorDemo.Pages
                 var dateData = DateRange.Split("-");
                 if (dateData.Length == 2)
                 {
-                    FilterList.DateRange = new DateRange(DateTime.Parse(dateData[0]), DateTime.Parse(dateData[1]));
+                    FilterList.DateRange = new DateRange(DateTime.Parse(dateData[0], CultureInfo.InvariantCulture),
+                        DateTime.Parse(dateData[1], CultureInfo.InvariantCulture));
                     hasChanged = true;
                 }
             }

--- a/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Logging.razor
+++ b/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Logging.razor
@@ -2,9 +2,9 @@
 @using Thinktecture.Extensions.Configuration
 @using Serilog.Events
 @inherits BaseComponent
-@inject ISerilogConfiguration loggingConfiguration
+@inject ISerilogConfiguration LoggingConfiguration
 <MudPageLayout Title="Logging">
-    <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@(() => loggingConfiguration.SetLevel(LogEventLevel.Debug))">Set debug</MudButton>
-    <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => loggingConfiguration.SetLevel(LogEventLevel.Information))">Set info</MudButton>
-    <MudButton Color="Color.Secondary" Variant="Variant.Outlined" OnClick="@(() => loggingConfiguration.ResetLevel())">Reset</MudButton>
+    <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@(() => LoggingConfiguration.SetLevel(LogEventLevel.Debug))">Set debug</MudButton>
+    <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => LoggingConfiguration.SetLevel(LogEventLevel.Information))">Set info</MudButton>
+    <MudButton Color="Color.Secondary" Variant="Variant.Outlined" OnClick="@(() => LoggingConfiguration.ResetLevel())">Reset</MudButton>
 </MudPageLayout>

--- a/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Options.razor
+++ b/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Options.razor
@@ -1,10 +1,10 @@
 ﻿@page "/Options"
 @using Sitko.Core.App
 @using System.Text.Json
-@inject Application application
+@inject Application Application
 <MudPageLayout Title="Options">
     <pre>
-    @JsonSerializer.Serialize(application.GetModulesOptions(), new JsonSerializerOptions
+    @JsonSerializer.Serialize(Application.GetModulesOptions(), new JsonSerializerOptions
     {
         WriteIndented = true
     })

--- a/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Scopes.razor
+++ b/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/Scopes.razor
@@ -2,122 +2,123 @@
 @page "/Bars/{Id:guid}/Edit"
 @inherits BaseComponent
 <MudPageLayout Title="Edit" Breadcrumbs="Breadcrumbs" Description="Page description">
-    <BarForm EntityId="Id" Debug="true">
-        <MudPaper Class="pa-4">
-            <MudGrid>
-                <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Class="mb-4">Multiple file input</MudText>
-                    <MudTextField Label="Bar" @bind-Value="@context.Entity.Bar" For="() => context.Entity.Bar"></MudTextField>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Class="mb-4">Edit Foo</MudText>
-                    @if (context.Entity.Foo is not null)
-                    {
-                        <MudTextField Label="Foo" @bind-Value="@context.Entity.Foo.Foo" For="() => context.Entity.Foo.Foo"></MudTextField>
-                    }
-                    <div>
-                        <MudButton Class="mr-3" Variant="Variant.Filled" Color="Color.Primary" OnClick="() => context.SetFoo()">Set foo</MudButton>
-                        <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="() => context.DeleteFoo()">Delete foo</MudButton>
-                    </div>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Class="mb-4">Edit Foos</MudText>
-                    @foreach (var foo in context.Entity.Foos)
-                    {
-                        <MudTextField Label="Foo" @bind-Value="@foo.Foo" For="() => foo.Foo" Class="mt-2"></MudTextField>
-                        <MudButton Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled" Class="mt-2" OnClick="() => context.RemoveFoo(foo)">Remove foo</MudButton>
-                    }
-                    <div>
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => context.AddFoo()">Add foo</MudButton>
-                    </div>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Class="mb-4">Current storage items</MudText>
-                    @if (context.Entity.StorageItem is not null)
-                    {
-                        <MudText>Storage item: @context.Entity.StorageItem</MudText>
-                    }
-                    @foreach (var file in context.Entity.StorageItems)
-                    {
-                        <p>Storage item: @file</p>
-                    }
-                </MudItem>
-                <MudItem xs="12">
-                    <Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload
-                        Label="Simple file input"
-                        HelperText="Bla-bla-bla"
-                        Storage="Storage"
-                        @bind-Value="context.Entity.StorageItem"
-                        For="() => context.Entity.StorageItem"
-                        UploadPath="bars"
-                        MaxFileSize="@(2 * 1024 * 1024)"
-                        GenerateMetadata="@((_, _) => GenerateMetadataAsync())">
-                    </Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Class="mb-4">Simple custom file input</MudText>
-                    <Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload
-                        Storage="Storage"
-                        @bind-Value="context.Entity.StorageItem"
-                        For="() => context.Entity.StorageItem"
-                        UploadPath="bars"
-                        MaxFileSize="@(2 * 1024 * 1024)"
-                        GenerateMetadata="@((_, _) => GenerateMetadataAsync())">
-                        <ChildContent Context="upload">
-                            PRESS ME
-                        </ChildContent>
-                    </Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudPaper Class="pa-4">
+    <BarForm @ref="Form" EntityId="Id" Debug="true">
+        <ChildContent Context="formContext">
+            <MudPaper Class="pa-4">
+                <MudGrid>
+                    <MudItem xs="12">
                         <MudText Typo="Typo.h6" Class="mb-4">Multiple file input</MudText>
-                        <MudFilesUpload
+                        <MudTextField Label="Bar" @bind-Value="@formContext.Entity.Bar" For="() => formContext.Entity.Bar"></MudTextField>
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudText Typo="Typo.h6" Class="mb-4">Edit Foo</MudText>
+                        @if (formContext.Entity.Foo is not null)
+                        {
+                            <MudTextField Label="Foo" @bind-Value="@formContext.Entity.Foo.Foo" For="() => formContext.Entity.Foo.Foo"></MudTextField>
+                        }
+                        <div>
+                            <MudButton Class="mr-3" Variant="Variant.Filled" Color="Color.Primary" OnClick="() => Form.SetFoo()">Set foo</MudButton>
+                            <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="() => Form.DeleteFoo()">Delete foo</MudButton>
+                        </div>
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudText Typo="Typo.h6" Class="mb-4">Edit Foos</MudText>
+                        @foreach (var foo in formContext.Entity.Foos)
+                        {
+                            <MudTextField Label="Foo" @bind-Value="@foo.Foo" For="() => foo.Foo" Class="mt-2"></MudTextField>
+                            <MudButton Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled" Class="mt-2" OnClick="() => Form.RemoveFoo(foo)">Remove foo</MudButton>
+                        }
+                        <div>
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => Form.AddFoo()">Add foo</MudButton>
+                        </div>
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudText Typo="Typo.h6" Class="mb-4">Current storage items</MudText>
+                        @if (formContext.Entity.StorageItem is not null)
+                        {
+                            <MudText>Storage item: @formContext.Entity.StorageItem</MudText>
+                        }
+                        @foreach (var file in formContext.Entity.StorageItems)
+                        {
+                            <p>Storage item: @file</p>
+                        }
+                    </MudItem>
+                    <MudItem xs="12">
+                        <Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload
+                            Label="Simple file input"
+                            HelperText="Bla-bla-bla"
                             Storage="Storage"
-                            TCollection="ValueCollection<StorageItem>"
-                            @bind-Value="context.Entity.StorageItems"
-                            For="() => context.Entity.StorageItems"
+                            @bind-Value="formContext.Entity.StorageItem"
+                            For="() => formContext.Entity.StorageItem"
+                            UploadPath="bars"
+                            MaxFileSize="@(2 * 1024 * 1024)"
+                            GenerateMetadata="@((_, _) => GenerateMetadataAsync())"/>
+
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudText Typo="Typo.h6" Class="mb-4">Simple custom file input</MudText>
+                        <Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload
+                            Storage="Storage"
+                            @bind-Value="formContext.Entity.StorageItem"
+                            For="() => formContext.Entity.StorageItem"
                             UploadPath="bars"
                             MaxFileSize="@(2 * 1024 * 1024)"
                             GenerateMetadata="@((_, _) => GenerateMetadataAsync())">
-                        </MudFilesUpload>
-                    </MudPaper>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Class="mb-4">Single image</MudText>
-                    <Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload
-                        Storage="Storage"
-                        DisplayMode="FileUploadDisplayMode.Image"
-                        @bind-Value="context.Entity.StorageItem"
-                        For="() => context.Entity.StorageItem"
-                        UploadPath="bars"
-                        MaxFileSize="@(2 * 1024 * 1024)"
-                        GenerateMetadata="@((_, _) => GenerateMetadataAsync())">
-                    </Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudPaper Class="pa-4">
-                        <MudText Typo="Typo.h6" Class="mb-4">Multiple image</MudText>
-                        <MudFilesUpload
+                            <ChildContent Context="_">
+                                PRESS ME
+                            </ChildContent>
+                        </Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload>
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudPaper Class="pa-4">
+                            <MudText Typo="Typo.h6" Class="mb-4">Multiple file input</MudText>
+                            <MudFilesUpload
+                                Storage="Storage"
+                                TCollection="ValueCollection<StorageItem>"
+                                @bind-Value="formContext.Entity.StorageItems"
+                                For="() => formContext.Entity.StorageItems"
+                                UploadPath="bars"
+                                MaxFileSize="@(2 * 1024 * 1024)"
+                                GenerateMetadata="@((_, _) => GenerateMetadataAsync())"/>
+
+                        </MudPaper>
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudText Typo="Typo.h6" Class="mb-4">Single image</MudText>
+                        <Sitko.Core.Blazor.MudBlazorComponents.MudFileUpload
                             Storage="Storage"
-                            TCollection="ValueCollection<StorageItem>"
                             DisplayMode="FileUploadDisplayMode.Image"
-                            @bind-Value="context.Entity.StorageItems"
-                            For="() => context.Entity.StorageItems"
+                            @bind-Value="formContext.Entity.StorageItem"
+                            For="() => formContext.Entity.StorageItem"
                             UploadPath="bars"
-                            MaxAllowedFiles="5"
                             MaxFileSize="@(2 * 1024 * 1024)"
-                            GenerateMetadata="@((_, _) => GenerateMetadataAsync())">
-                        </MudFilesUpload>
-                    </MudPaper>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudPaper Class="mt-2 pa-3">
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!context.CanSave())" OnClick="@context.SaveEntityAsync">Save</MudButton>
-                        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Disabled="@(!context.HasChanges)" OnClick="@context.ResetAsync">Reset</MudButton>
-                    </MudPaper>
-                </MudItem>
-            </MudGrid>
-        </MudPaper>
+                            GenerateMetadata="@((_, _) => GenerateMetadataAsync())"/>
+
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudPaper Class="pa-4">
+                            <MudText Typo="Typo.h6" Class="mb-4">Multiple image</MudText>
+                            <MudFilesUpload
+                                Storage="Storage"
+                                TCollection="ValueCollection<StorageItem>"
+                                DisplayMode="FileUploadDisplayMode.Image"
+                                @bind-Value="formContext.Entity.StorageItems"
+                                For="() => formContext.Entity.StorageItems"
+                                UploadPath="bars"
+                                MaxAllowedFiles="5"
+                                MaxFileSize="@(2 * 1024 * 1024)"
+                                GenerateMetadata="@((_, _) => GenerateMetadataAsync())"/>
+                        </MudPaper>
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudPaper Class="mt-2 pa-3">
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!formContext.Form.CanSave())" OnClick="@formContext.Form.SaveEntityAsync">Save</MudButton>
+                            <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Disabled="@(!formContext.Form.HasChanges)" OnClick="@formContext.Form.ResetAsync">Reset</MudButton>
+                        </MudPaper>
+                    </MudItem>
+                </MudGrid>
+            </MudPaper>
+        </ChildContent>
     </BarForm>
 </MudPageLayout>
 
@@ -139,5 +140,7 @@
         new BreadcrumbItem("Foo1", "/"),
         new BreadcrumbItem("Bar", "/")
     };
+
+    private BarForm Form { get; set; } = null!;
 
 }

--- a/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/SwitchForm.razor
+++ b/apps/Sitko.Core.Apps.MudBlazorDemo/Pages/SwitchForm.razor
@@ -3,24 +3,26 @@
 @inherits BaseComponent
 @if (editMode)
 {
-    <BarForm EntityId="Id" Debug="true" OnAfterSave="@(_ => {editMode = false; return NotifyStateChangeAsync();})">
-        <MudTextField Label="Bar" @bind-Value="@context.Entity.Bar" For="() => context.Entity.Bar"></MudTextField>
-        <MudText>Simple Foo</MudText>
-        @if (context.Entity.Foo is not null)
-        {
-            <MudTextField Label="Foo" @bind-Value="@context.Entity.Foo.Foo" For="() => context.Entity.Foo.Foo"></MudTextField>
-        }
-        <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="() => context.DeleteFoo()">Delete foo</MudButton>
-        <MudText>Multiple foo</MudText>
-        @foreach (var foo in context.Entity.Foos)
-        {
-            <MudTextField Label="Foo" @bind-Value="@foo.Foo" For="() => foo.Foo"></MudTextField>
-            <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="() => { context.Entity.Foos.Remove(foo); context.NotifyChange();}">Remove foo</MudButton>
-        }
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => context.AddFoo()">Add foo</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => context.SetFoo()">Set foo</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!context.CanSave())" OnClick="@context.SaveEntityAsync">Save</MudButton>
-        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Disabled="@(!context.HasChanges)" OnClick="@context.ResetAsync">Reset</MudButton>
+    <BarForm @ref="Form" EntityId="Id" Debug="true" OnAfterSave="@(_ => {editMode = false; return NotifyStateChangeAsync();})">
+        <ChildContent>
+            <MudTextField Label="Bar" @bind-Value="@context.Entity.Bar" For="() => context.Entity.Bar"></MudTextField>
+            <MudText>Simple Foo</MudText>
+            @if (context.Entity.Foo is not null)
+            {
+                <MudTextField Label="Foo" @bind-Value="@context.Entity.Foo.Foo" For="() => context.Entity.Foo.Foo"></MudTextField>
+            }
+            <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="() => Form.DeleteFoo()">Delete foo</MudButton>
+            <MudText>Multiple foo</MudText>
+            @foreach (var foo in context.Entity.Foos)
+            {
+                <MudTextField Label="Foo" @bind-Value="@foo.Foo" For="() => foo.Foo"></MudTextField>
+                <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="() => { context.Entity.Foos.Remove(foo); Form.NotifyChange();}">Remove foo</MudButton>
+            }
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => Form.AddFoo()">Add foo</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => Form.SetFoo()">Set foo</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!context.Form.CanSave())" OnClick="@context.Form.SaveEntityAsync">Save</MudButton>
+            <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Disabled="@(!context.Form.HasChanges)" OnClick="@context.Form.ResetAsync">Reset</MudButton>
+        </ChildContent>
     </BarForm>
 @*     <BarForm Layout="@FormLayout.Vertical" EntityId="Id" Debug="true" OnAfterSave="@(_ => {editMode = false; return NotifyStateChangeAsync();})"> *@
 @*         <AntFormItem Label="Bar" Hint="Bar help"> *@
@@ -64,4 +66,6 @@ else
     public Guid Id { get; set; }
 
     private bool editMode;
+    private BarForm Form { get; set; } = null!;
+
 }

--- a/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudForm.razor
+++ b/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudForm.razor
@@ -7,7 +7,7 @@
     <MudEditForm TEntity="TEntity" Entity="Entity" @ref="FormInstance">
         <Sitko.Core.Blazor.FluentValidation.FluentValidator/>
         <Sitko.Core.Blazor.Forms.FormEditContextCatcher Form="this"/>
-        @ChildContentFragment
+        @ChildContent(FormContext)
         @if (Debug)
         {
             <MudFormDebug TEntity="TEntity" Form="this"></MudFormDebug>
@@ -23,7 +23,7 @@ else
         }
         else
         {
-            @ChildContentFragment
+            @ChildContent(FormContext)
             @if (Debug)
             {
                 <MudFormDebug TEntity="TEntity" Form="this"></MudFormDebug>

--- a/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudForm.razor.cs
+++ b/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudForm.razor.cs
@@ -5,18 +5,10 @@ using Sitko.Core.Blazor.Forms;
 // ReSharper disable once CheckNamespace
 namespace Sitko.Core.Blazor.MudBlazorComponents;
 
-public class MudEntityForm<TEntity> : BaseMudForm<TEntity>
-    where TEntity : class, new()
-{
-    [EditorRequired] [Parameter] public RenderFragment<BaseMudForm<TEntity>> ChildContent { get; set; } = null!;
-
-    protected override RenderFragment ChildContentFragment => ChildContent(this);
-}
-
 public abstract partial class BaseMudForm<TEntity>
     where TEntity : class, new()
 {
-    protected abstract RenderFragment ChildContentFragment { get; }
+    [Parameter] [EditorRequired] public RenderFragment<FormContext<TEntity>> ChildContent { get; set; } = null!;
     [Parameter] public RenderFragment? LoadingContent { get; set; }
     protected MudEditForm<TEntity>? FormInstance { get; set; }
     [Inject] public ISnackbar Snackbar { get; set; } = null!;

--- a/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudRepositoryForm.razor
+++ b/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudRepositoryForm.razor
@@ -8,7 +8,7 @@
     <MudEditForm TEntity="TEntity" Entity="Entity" @ref="FormInstance">
         <Sitko.Core.Blazor.FluentValidation.FluentValidator/>
         <Sitko.Core.Blazor.Forms.FormEditContextCatcher Form="this"/>
-        @ChildContentFragment
+        @ChildContent(FormContext)
         @if (Debug)
         {
             <MudFormDebug TEntity="TEntity" Form="this"></MudFormDebug>
@@ -24,7 +24,7 @@ else
         }
         else
         {
-            @ChildContentFragment
+            @ChildContent(FormContext)
             @if (Debug)
             {
                 <MudFormDebug TEntity="TEntity" Form="this"></MudFormDebug>

--- a/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudRepositoryForm.razor.cs
+++ b/src/Sitko.Core.Blazor.MudBlazor/Components/Form/BaseMudRepositoryForm.razor.cs
@@ -1,20 +1,10 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor;
+using Sitko.Core.Blazor.Forms;
 using Sitko.Core.Repository;
 
 // ReSharper disable once CheckNamespace
 namespace Sitko.Core.Blazor.MudBlazorComponents;
-
-public class MudRepositoryForm<TEntity, TEntityPk> : BaseMudRepositoryForm<TEntity, TEntityPk,
-    IRepository<TEntity, TEntityPk>>
-    where TEntity : class, IEntity<TEntityPk>, new() where TEntityPk : notnull
-{
-    [EditorRequired]
-    [Parameter]
-    public RenderFragment<MudRepositoryForm<TEntity, TEntityPk>> ChildContent { get; set; } = null!;
-
-    protected override RenderFragment ChildContentFragment => ChildContent(this);
-}
 
 public abstract partial class BaseMudRepositoryForm<TEntity, TEntityPk, TRepository>
     where TEntity : class, IEntity<TEntityPk>, new()
@@ -24,7 +14,8 @@ public abstract partial class BaseMudRepositoryForm<TEntity, TEntityPk, TReposit
     protected MudEditForm<TEntity>? FormInstance { get; set; }
     [Parameter] public bool Debug { get; set; }
     [Inject] public ISnackbar Snackbar { get; set; } = null!;
-    protected abstract RenderFragment ChildContentFragment { get; }
+
+    [Parameter] [EditorRequired] public RenderFragment<FormContext<TEntity>> ChildContent { get; set; } = null!;
 
     [Parameter] public RenderFragment? LoadingContent { get; set; }
 
@@ -53,4 +44,3 @@ public abstract partial class BaseMudRepositoryForm<TEntity, TEntityPk, TReposit
         await StopLoadingAsync();
     }
 }
-

--- a/src/Sitko.Core.Blazor/Forms/BaseForm.cs
+++ b/src/Sitko.Core.Blazor/Forms/BaseForm.cs
@@ -67,7 +67,7 @@ public abstract class BaseForm<TEntity> : BaseForm where TEntity : class, new()
     private CompareLogic? comparer;
     private TEntity? currentEntity;
     protected TEntity? EntitySnapshot { get; private set; }
-
+    protected FormContext<TEntity> FormContext { get; private set; } = null!;
     public bool IsNew { get; protected set; }
 
     public TEntity Entity
@@ -75,7 +75,6 @@ public abstract class BaseForm<TEntity> : BaseForm where TEntity : class, new()
         get => currentEntity ?? throw new InvalidOperationException("Entity is not initialized");
         private set => currentEntity = value;
     }
-
 
     [Parameter] public Func<TEntity, Task>? OnAfterSave { get; set; }
     [Parameter] public Func<TEntity, Task>? OnAfterCreate { get; set; }
@@ -113,6 +112,7 @@ public abstract class BaseForm<TEntity> : BaseForm where TEntity : class, new()
         (IsNew, Entity) = await GetEntityAsync();
         await InitializeEntityAsync(Entity);
         EntitySnapshot = CreateEntitySnapshot(Entity);
+        FormContext = new(Entity, this);
     }
 
     protected abstract Task<(bool IsNew, TEntity Entity)> GetEntityAsync();

--- a/src/Sitko.Core.Blazor/Forms/FormContext.cs
+++ b/src/Sitko.Core.Blazor/Forms/FormContext.cs
@@ -1,0 +1,3 @@
+namespace Sitko.Core.Blazor.Forms;
+
+public record FormContext<TEntity>(TEntity Entity, BaseForm<TEntity> Form) where TEntity : class, new();


### PR DESCRIPTION
Intoduce FormContext to use in templates. No need for overriding ChildContext in every form.