### PR TITLE
feat(remoterepository): pass includes as expressions

### DIFF
--- a/src/Sitko.Core.Repository.Remote.Server/BaseRemoteRepositoryController.cs
+++ b/src/Sitko.Core.Repository.Remote.Server/BaseRemoteRepositoryController.cs
@@ -22,12 +22,12 @@ public class BaseRemoteRepositoryController<TEntity, TEntityPK> : Controller
 
 
     [HttpPost("GetAll")]
-    public async Task<IActionResult> GetAllAsync([FromBody] SerializedQueryData queryData)
+    public async Task<IActionResult> GetAllAsync([FromBody] SerializedQueryDataRequest queryData)
     {
         try
         {
             var result = await repository.GetAllAsync(repositoryQuery =>
-                new SerializedQuery<TEntity>(queryData).Apply(repositoryQuery));
+                new SerializedQuery<TEntity>(queryData.Data).Apply(repositoryQuery));
             return Ok(JsonHelper.SerializeWithMetadata(new ListResult<TEntity>(result.items, result.itemsCount)));
         }
         catch (Exception ex)
@@ -37,10 +37,11 @@ public class BaseRemoteRepositoryController<TEntity, TEntityPK> : Controller
     }
 
     [HttpPost("Get")]
-    public async Task<IActionResult> GetAsync([FromBody] SerializedQueryData queryData)
+    public async Task<IActionResult> GetAsync([FromBody] SerializedQueryDataRequest queryDataJson)
     {
         try
         {
+            var queryData = queryDataJson.Data;
             var result = await repository.GetAsync(repositoryQuery =>
                 new SerializedQuery<TEntity>(queryData).Apply(repositoryQuery));
             if (result is null)
@@ -173,11 +174,11 @@ public class BaseRemoteRepositoryController<TEntity, TEntityPK> : Controller
     }
 
     [HttpPost("Sum")]
-    public async Task<IActionResult> SumAsync([FromBody] SerializedQueryData queryData, SumType type)
+    public async Task<IActionResult> SumAsync([FromBody] SerializedQueryDataRequest queryData, SumType type)
     {
         try
         {
-            var query = new SerializedQuery<TEntity>(queryData);
+            var query = new SerializedQuery<TEntity>(queryData.Data);
             object result = type switch
             {
                 SumType.TypeInt => await repository.SumAsync(q => query.Apply(q), query.SelectExpression<int>()),
@@ -211,4 +212,3 @@ public class BaseRemoteRepositoryController<TEntity, TEntityPK> : Controller
         }
     }
 }
-

--- a/src/Sitko.Core.Repository.Remote/HttpRepositoryTransport.cs
+++ b/src/Sitko.Core.Repository.Remote/HttpRepositoryTransport.cs
@@ -38,15 +38,16 @@ public class HttpRepositoryTransport : IRemoteRepositoryTransport
         CancellationToken cancellationToken = default) where TEntity : class
     {
         var serialized = query.Serialize();
-        return await PostRequestAsync<SerializedQueryData, TEntity?>($"/{typeof(TEntity).Name}" + "/Get",
-            serialized.Data, cancellationToken);
+        return await PostRequestAsync<SerializedQueryDataRequest, TEntity?>($"/{typeof(TEntity).Name}" + "/Get",
+            new SerializedQueryDataRequest(JsonHelper.SerializeWithMetadata(serialized.Data)), cancellationToken);
     }
 
     public async Task<int> CountAsync<TEntity>(RemoteRepositoryQuery<TEntity> configureQuery,
         CancellationToken cancellationToken = default) where TEntity : class
     {
         var serialized = configureQuery.Serialize();
-        return await PostRequestAsync<SerializedQueryData, int>($"/{typeof(TEntity).Name}" + "/Count", serialized.Data,
+        return await PostRequestAsync<SerializedQueryDataRequest, int>($"/{typeof(TEntity).Name}" + "/Count",
+            new SerializedQueryDataRequest(JsonHelper.SerializeWithMetadata(serialized.Data)),
             cancellationToken);
     }
 
@@ -55,8 +56,9 @@ public class HttpRepositoryTransport : IRemoteRepositoryTransport
         CancellationToken cancellationToken = default) where TEntity : class where TReturn : struct
     {
         var serialized = configureQuery.Serialize();
-        return await PostRequestAsync<SerializedQueryData, TReturn>(
-            $"/{typeof(TEntity).Name}" + "/Sum?type=" + type, serialized.Data, cancellationToken);
+        return await PostRequestAsync<SerializedQueryDataRequest, TReturn>(
+            $"/{typeof(TEntity).Name}" + "/Sum?type=" + type,
+            new SerializedQueryDataRequest(JsonHelper.SerializeWithMetadata(serialized.Data)), cancellationToken);
     }
 
     public async Task<AddOrUpdateOperationResult<TEntity, TEntityPk>?> AddAsync<TEntity, TEntityPk>(TEntity entity,
@@ -89,8 +91,9 @@ public class HttpRepositoryTransport : IRemoteRepositoryTransport
         CancellationToken cancellationToken = default) where TEntity : class
     {
         var serialized = query.Serialize();
-        var result = await PostRequestAsync<SerializedQueryData, ListResult<TEntity>>(
-            $"/{typeof(TEntity).Name}" + "/GetAll", serialized.Data, cancellationToken);
+        var result = await PostRequestAsync<SerializedQueryDataRequest, ListResult<TEntity>>(
+            $"/{typeof(TEntity).Name}" + "/GetAll",
+            new SerializedQueryDataRequest(JsonHelper.SerializeWithMetadata(serialized.Data)), cancellationToken);
         if (result is null)
         {
             return (Array.Empty<TEntity>(), 0);
@@ -135,4 +138,3 @@ public class HttpRepositoryTransport : IRemoteRepositoryTransport
 public record UpdateModel<TEntity>(TEntity Entity, TEntity? OldEntity) where TEntity : class;
 
 public record ListResult<TEntity>(TEntity[] Items, int ItemsCount);
-

--- a/src/Sitko.Core.Repository.Remote/RemoteRepositoryQuery.cs
+++ b/src/Sitko.Core.Repository.Remote/RemoteRepositoryQuery.cs
@@ -5,7 +5,7 @@ namespace Sitko.Core.Repository.Remote;
 public class RemoteRepositoryQuery<TEntity> : BaseRepositoryQuery<TEntity> where TEntity : class
 {
     private readonly List<IRemoteIncludableQuery> includableQueries = new();
-    private readonly List<string> includes = new();
+    private readonly List<string> includesByName = new();
     private readonly List<Expression<Func<TEntity, object>>> orderByDescendingExpressions = new();
     private readonly List<Expression<Func<TEntity, object>>> orderByExpressions = new();
     private readonly List<(string propertyName, bool isDescending)> orderByStringExpressions = new();
@@ -23,7 +23,7 @@ public class RemoteRepositoryQuery<TEntity> : BaseRepositoryQuery<TEntity> where
         whereByStringExpressions = source.whereByStringExpressions;
         orderByExpressions = source.orderByExpressions;
         orderByDescendingExpressions = source.orderByExpressions;
-        includes = source.includes;
+        includesByName = source.includesByName;
         includableQueries = source.includableQueries;
         selectExpression = source.selectExpression;
     }
@@ -31,7 +31,7 @@ public class RemoteRepositoryQuery<TEntity> : BaseRepositoryQuery<TEntity> where
 
     public override IRepositoryQuery<TEntity> Include(string navigationPropertyPath)
     {
-        includes.Add(navigationPropertyPath);
+        includesByName.Add(navigationPropertyPath);
         return this;
     }
 
@@ -93,19 +93,11 @@ public class RemoteRepositoryQuery<TEntity> : BaseRepositoryQuery<TEntity> where
     public override IIncludableRepositoryQuery<TEntity, TProperty> Include<TProperty>(
         Expression<Func<TEntity, TProperty>> navigationPropertyPath)
     {
-        var propertyName = GetPropertyName(navigationPropertyPath);
-        var includableQuery = new IncludableRemoteRepositoryQuery<TEntity, TProperty>(this, propertyName);
+        var includableQuery =
+            new IncludableRemoteRepositoryQuery<TEntity, TProperty>(this, navigationPropertyPath);
         includableQueries.Add(includableQuery);
         return includableQuery;
     }
-
-    protected static string GetPropertyName<TExpressionEntity, TProperty>(
-        Expression<Func<TExpressionEntity, TProperty>> navigationPropertyPath)
-    {
-        var expression = (MemberExpression)navigationPropertyPath.Body;
-        return expression.Member.Name;
-    }
-
 
     protected override void ApplySort((string propertyName, bool isDescending) sortQuery) =>
         orderByStringExpressions.Add(sortQuery);
@@ -113,18 +105,14 @@ public class RemoteRepositoryQuery<TEntity> : BaseRepositoryQuery<TEntity> where
     public SerializedQuery<TEntity>
         Serialize()
     {
-        foreach (var includableQuery in includableQueries)
-        {
-            includes.Add(includableQuery.GetFullPath());
-        }
-
         var serializedQuery = new SerializedQuery<TEntity>()
             .AddWhereExpressions(whereExpressions)
             .AddWhereByStringExpressions(whereByStringExpressions)
             .AddOrderByExpressions(orderByExpressions)
             .AddOrderByDescendingExpressions(orderByDescendingExpressions)
             .AddOrderByStringExpressions(orderByStringExpressions)
-            .AddIncludes(includes);
+            .AddIncludesByName(includesByName)
+            .AddIncludes(includableQueries);
         if (selectExpression is not null)
         {
             serializedQuery.SetSelectExpression(selectExpression);
@@ -153,21 +141,17 @@ public class RemoteRepositoryQuery<TEntity> : BaseRepositoryQuery<TEntity> where
 public class IncludableRemoteRepositoryQuery<TEntity, TProperty> : RemoteRepositoryQuery<TEntity>,
     IIncludableRepositoryQuery<TEntity, TProperty>, IRemoteIncludableQuery where TEntity : class
 {
-    private readonly string propertyName;
-
+    private readonly Expression expression;
     private readonly RemoteRepositoryQuery<TEntity> source;
 
-    internal IncludableRemoteRepositoryQuery(RemoteRepositoryQuery<TEntity> source, string propertyName) : base(source)
+    internal IncludableRemoteRepositoryQuery(RemoteRepositoryQuery<TEntity> source, Expression expression) :
+        base(source)
     {
         this.source = source;
-        this.propertyName = propertyName;
-        if (source is IRemoteIncludableQuery includableSource)
-        {
-            includableSource.SetChild(this);
-        }
+        this.expression = expression;
     }
 
-    private IRemoteIncludableQuery? Child { get; set; }
+    private IChildRemoteIncludableQuery? Child { get; set; }
 
     public override IRepositoryQuery<TEntity> Take(int take)
     {
@@ -190,30 +174,67 @@ public class IncludableRemoteRepositoryQuery<TEntity, TProperty> : RemoteReposit
     public IIncludableRepositoryQuery<TEntity, TNextProperty> ThenIncludeFromEnumerableInternal<TNextProperty,
         TPreviousProperty>(
         Expression<Func<TPreviousProperty, TNextProperty>> navigationPropertyPath) =>
-        new IncludableRemoteRepositoryQuery<TEntity, TNextProperty>(this, GetPropertyName(navigationPropertyPath));
+        IncludableRemoteRepositoryQuery<TEntity, TNextProperty>.CreateChild<TPreviousProperty>(this,
+            navigationPropertyPath);
 
     public IIncludableRepositoryQuery<TEntity, TNextProperty> ThenIncludeFromSingleInternal<TNextProperty,
         TPreviousProperty>(
         Expression<Func<TPreviousProperty, TNextProperty>> navigationPropertyPath) =>
-        new IncludableRemoteRepositoryQuery<TEntity, TNextProperty>(this, GetPropertyName(navigationPropertyPath));
+        IncludableRemoteRepositoryQuery<TEntity, TNextProperty>.CreateChild<TPreviousProperty>(this,
+            navigationPropertyPath);
 
-    public void SetChild(IRemoteIncludableQuery query) => Child = query;
+    public void SetChild<TPreviousProperty>(IRemoteIncludableQuery query) =>
+        Child = new ChildRemoteIncludableQuery<TPreviousProperty>(query);
 
-    public string GetFullPath()
+    public IInclude GetInclude(ExpressionSerializer serializer)
     {
-        var path = propertyName;
+        var include = new Include<TProperty>(serializer.Serialize(expression));
         if (Child is not null)
         {
-            path += $".{Child.GetFullPath()}";
+            return Child.GetChildInclude(include, serializer);
         }
 
-        return path;
+        return include;
+    }
+
+    public IInclude GetChildInclude<TPreviousProperty>(IInclude parentInclude, ExpressionSerializer serializer)
+    {
+        var include = new Include<TProperty, TPreviousProperty>(serializer.Serialize(expression), parentInclude);
+        if (Child is not null)
+        {
+            return Child.GetChildInclude(include, serializer);
+        }
+
+        return include;
+    }
+
+    internal static IncludableRemoteRepositoryQuery<TEntity, TProperty> CreateChild<TPreviousProperty>(
+        RemoteRepositoryQuery<TEntity> source, Expression expression)
+    {
+        var child = new IncludableRemoteRepositoryQuery<TEntity, TProperty>(source, expression);
+        if (source is IRemoteIncludableQuery includableSource)
+        {
+            includableSource.SetChild<TPreviousProperty>(child);
+        }
+
+        return child;
     }
 }
 
 public interface IRemoteIncludableQuery
 {
-    public string GetFullPath();
-    public void SetChild(IRemoteIncludableQuery query);
+    public void SetChild<TPreviousProperty>(IRemoteIncludableQuery query);
+    IInclude GetInclude(ExpressionSerializer serializer);
+    IInclude GetChildInclude<TPreviousProperty>(IInclude parentInclude, ExpressionSerializer serializer);
 }
 
+public interface IChildRemoteIncludableQuery
+{
+    IInclude GetChildInclude(IInclude parentInclude, ExpressionSerializer serializer);
+}
+
+public record ChildRemoteIncludableQuery<TPreviousProperty>(IRemoteIncludableQuery Query) : IChildRemoteIncludableQuery
+{
+    public IInclude GetChildInclude(IInclude parentInclude, ExpressionSerializer serializer) =>
+        Query.GetChildInclude<TPreviousProperty>(parentInclude, serializer);
+}

--- a/src/Sitko.Core.Repository.Remote/SerializedQueryData.cs
+++ b/src/Sitko.Core.Repository.Remote/SerializedQueryData.cs
@@ -1,4 +1,13 @@
-﻿namespace Sitko.Core.Repository.Remote;
+﻿using System.Linq.Expressions;
+using Sitko.Core.App.Json;
+
+namespace Sitko.Core.Repository.Remote;
+
+public record SerializedQueryDataRequest(string SerializedQueryDataJson)
+{
+    public SerializedQueryData Data =>
+        JsonHelper.DeserializeWithMetadata<SerializedQueryData>(SerializedQueryDataJson)!;
+}
 
 public record SerializedQueryData
 {
@@ -7,11 +16,54 @@ public record SerializedQueryData
     public List<string> OrderBy { get; set; } = new();
     public List<string> OrderByDescending { get; set; } = new();
     public List<OrderByString> OrderByString { get; set; } = new();
-    public List<string> Includes { get; set; } = new();
+    public List<string> IncludesByName { get; set; } = new();
+    public List<IInclude> Includes { get; set; } = new();
     public int? Limit { get; set; }
     public int? Offset { get; set; }
     public string? SelectExpressionString { get; set; }
 }
 
 public record WhereByString(string WhereStr, object?[]? Values);
-public record OrderByString(string PropertyName,  bool IsDescending);
+
+public record OrderByString(string PropertyName, bool IsDescending);
+
+public interface IInclude
+{
+    IRepositoryQuery<TEntity> Apply<TEntity>(IRepositoryQuery<TEntity> query, ExpressionSerializer serializer)
+        where TEntity : class;
+}
+
+public record Include<TProperty>(string Expression) : IInclude
+{
+    public IRepositoryQuery<TEntity> Apply<TEntity>(IRepositoryQuery<TEntity> query,
+        ExpressionSerializer serializer)
+        where TEntity : class
+    {
+        var ex = serializer.Deserialize<Expression<Func<TEntity, TProperty>>>(Expression);
+        query = query.Include(ex);
+        return query;
+    }
+}
+
+public record Include<TProperty, TPreviousProperty>(string Expression, IInclude Previous) : IInclude
+{
+    public IRepositoryQuery<TEntity> Apply<TEntity>(IRepositoryQuery<TEntity> query, ExpressionSerializer serializer)
+        where TEntity : class
+    {
+        var ex = serializer.Deserialize<Expression<Func<TPreviousProperty, TProperty>>>(Expression);
+        query = Previous.Apply(query, serializer);
+        if (query is IIncludableRepositoryQuery<TEntity, TPreviousProperty> includableQuery)
+        {
+            query = includableQuery.ThenInclude(ex);
+        }
+        else
+        {
+            if (query is IIncludableRepositoryQuery<TEntity, IEnumerable<TPreviousProperty>> enumerableIncludableQuery)
+            {
+                query = enumerableIncludableQuery.ThenInclude(ex);
+            }
+        }
+
+        return query;
+    }
+}


### PR DESCRIPTION
Support complex includes with filters. Old approach with properties names can't do that, so we need to pass include expressions to server.

P.S. No reflection, pure generics pleasure