### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     ports:
       - "8200:8200"
   kafka:
-    image: docker.io/bitnami/kafka:3.9
+    image: docker.io/soldevelo/kafka:3.9
     ports:
       - "9092:9092"
     volumes:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kafka:3.9` → [`soldevelo/kafka:3.9`](https://hub.docker.com/r/soldevelo/kafka)